### PR TITLE
feat: Add Arbitrum and Polygon chains to configuration

### DIFF
--- a/src/config/all-in-one/chains.ts
+++ b/src/config/all-in-one/chains.ts
@@ -164,16 +164,17 @@ export const SupportedChains = [
   {
     name: 'Ethereum',
     chainId: 1
+  },
+  // 👇 04/24, 2025 supported
+  {
+    name: popupsData.arbitrum.title,
+    chainId: popupsData.arbitrum.chainId
+  },
+  {
+    name: popupsData.polygon.title,
+    chainId: popupsData.polygon.chainId
   }
   // 👇 in testing
-  // {
-  //   name: popupsData.arbitrum.title,
-  //   chainId: popupsData.arbitrum.chainId
-  // },
-  // {
-  //   name: popupsData.polygon.title,
-  //   chainId: popupsData.polygon.chainId
-  // },
   // {
   //   name: popupsData.bnb.title,
   //   chainId: popupsData.bnb.chainId


### PR DESCRIPTION
Enabled support for Arbitrum and Polygon chains by uncommenting and including their details. Other chains like BNB remain in testing and are commented out for now.